### PR TITLE
Code improvement

### DIFF
--- a/cmb-field-map.php
+++ b/cmb-field-map.php
@@ -25,7 +25,8 @@ function pw_map_field( $field, $meta ) {
 	echo '<input type="hidden" class="latitude" name="' . $field->args( 'id' ) . '[latitude]" value="' . ( isset( $meta['latitude'] ) ? $meta['latitude'] : '' ) . '" />';
 	echo '<input type="hidden" class="longitude" name="' . $field->args( 'id' ) . '[longitude]" value="' . ( isset( $meta['longitude'] ) ? $meta['longitude'] : '' ) . '" />';
 
-	if ( ! empty( $field->args( 'desc' ) ) ) echo '<p class="cmb2-metabox-description">' . $field->args( 'desc' ) . '</p>';
+	$desc = $field->args('desc');
+	if ( ! empty( $desc ) ) echo '<p class="cmb2-metabox-description">' . $desc . '</p>';
 }
 add_filter( 'cmb2_render_pw_map', 'pw_map_field', 10, 2 );
 


### PR DESCRIPTION
Store description into a variable to avoid 'Can't use function return value in write context in...' errors.

-P
