### PR TITLE
gitignore for JetBrains IDE directory + GitHub Updater plugin meta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 nbproject
 thumb.db
 Thumbs.db
+.idea
 
 
 # Project specific files to ignore

--- a/cmb-field-map.php
+++ b/cmb-field-map.php
@@ -2,6 +2,7 @@
 /*
 Plugin Name: CMB2 Field Type: Google Maps
 Plugin URI: https://github.com/mustardBees/cmb_field_map
+GitHub Plugin URI: https://github.com/mustardBees/cmb_field_map
 Description: Google Maps field type for CMB2.
 Version: 2.1.1
 Author: Phil Wylie


### PR DESCRIPTION
A couple of minor changes - most importantly, the GitHub Updater plugin meta (https://github.com/afragen/github-updater) for one-click updating.