### PR TITLE
Add an action after display lat/long for other fields to be hooked in

### DIFF
--- a/cmb-field-map.php
+++ b/cmb-field-map.php
@@ -54,6 +54,8 @@ class PW_CMB2_Field_Google_Maps {
 			'class'      => 'pw-map-longitude',
 			'desc'       => '',
 		) );
+
+		do_action( 'pw-map-extra-extra-fields', $field, $field_escaped_value, $field_object_id, $field_object_type, $field_type_object );
 	}
 
 	/**


### PR DESCRIPTION
We're using this plugin on a project at WebDevStudios, and would rather not have to build our own fork for more fields inside of this, adding an action after displaying the fields is more than enough to hook in.

Thanks!