### PR TITLE
Setting and filter for API key

### DIFF
--- a/cmb-field-map.php
+++ b/cmb-field-map.php
@@ -79,7 +79,7 @@ class PW_CMB2_Field_Google_Maps {
 	/**
 	 * Enqueue scripts and styles
 	 */
-	public function setup_admin_scripts() {
+	public function setup_admin_scripts($api_key) {
 		wp_register_script( 'pw-google-maps-api', "https://maps.googleapis.com/maps/api/js?key={$api_key}&libraries=places", null, null );
 		wp_enqueue_script( 'pw-google-maps', plugins_url( 'js/script.js', __FILE__ ), array( 'pw-google-maps-api' ), self::VERSION );
 		wp_enqueue_style( 'pw-google-maps', plugins_url( 'css/style.css', __FILE__ ), array(), self::VERSION );

--- a/cmb-field-map.php
+++ b/cmb-field-map.php
@@ -18,7 +18,7 @@ class PW_CMB2_Field_Google_Maps {
 	/**
 	 * Current version number
 	 */
-	const VERSION = '2.1.1';
+	const VERSION = '2.1.2';
 
 	/**
 	 * Initialize the plugin by hooking into CMB2
@@ -32,7 +32,10 @@ class PW_CMB2_Field_Google_Maps {
 	 * Render field
 	 */
 	public function render_pw_map( $field, $field_escaped_value, $field_object_id, $field_object_type, $field_type_object ) {
-		$this->setup_admin_scripts();
+
+		$api_key = apply_filters( 'cmb2-pw-map-api-key', $field->args( 'api_key' ) );
+
+		$this->setup_admin_scripts( $api_key );
 
 		echo '<input type="text" class="large-text pw-map-search" id="' . $field->args( 'id' ) . '" />';
 
@@ -77,7 +80,7 @@ class PW_CMB2_Field_Google_Maps {
 	 * Enqueue scripts and styles
 	 */
 	public function setup_admin_scripts() {
-		wp_register_script( 'pw-google-maps-api', '//maps.googleapis.com/maps/api/js?libraries=places', null, null );
+		wp_register_script( 'pw-google-maps-api', "https://maps.googleapis.com/maps/api/js?key={$api_key}&libraries=places", null, null );
 		wp_enqueue_script( 'pw-google-maps', plugins_url( 'js/script.js', __FILE__ ), array( 'pw-google-maps-api' ), self::VERSION );
 		wp_enqueue_style( 'pw-google-maps', plugins_url( 'css/style.css', __FILE__ ), array(), self::VERSION );
 	}

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,13 @@
+{
+    "name": "Peytz_WordPress/cmb_field_map",
+    "description": "Google Maps field type for Custom Metaboxes and Fields for WordPress",
+    "type": "wordpress-plugin",
+    "keywords": ["wordpress", "plugin"],
+    "homepage": "https://github.com/mustardBees/cmb_field_map/",
+    "authors": [
+        {
+            "name": "Phil Wylie",
+            "homepage": "http://www.philwylie.co.uk/"
+        }
+    ]
+}


### PR DESCRIPTION
**Done:**
- Added support for passing API key as a field param
- Added a filter to allow passing the API key using add_filter
- Bump const VERSION to match current plugin version

**Considered but not done**
- Check to see if API key is set and display a error msg instead of rendering the map with errors