### PR TITLE
Improve field+map width on edit term screen

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -8,3 +8,7 @@
 .pw-map img {
 	max-width: none;
 }
+.cmb2-wrap.form-table .cmb-row.cmb-type-pw-map > .cmb-td{
+    width: 100%;
+    max-width: 540px;
+}


### PR DESCRIPTION
If this field is applied to a taxonomy on the edit screen of the terms its width is narrow and not fully sized.